### PR TITLE
Use RefCOCO exports for segmentation evaluation and make eval script configurable

### DIFF
--- a/eval_grefcoco_rec.sh
+++ b/eval_grefcoco_rec.sh
@@ -6,17 +6,18 @@ cd "${REPO_HOME}"
 
 # --- User editable values ---------------------------------------------------
 DATA_DIR=${DATA_DIR:-"${REPO_HOME}/data"}
-RUN_NAME=${RUN_NAME:-"Qwen2.5-VL-3B-Instruct-rec"}
+REFCOCO_EXPORT_BASE=${REFCOCO_EXPORT_BASE:-"${DATA_DIR}/refcoco_exports"}
+COCO_IMAGE_ROOT=${COCO_IMAGE_ROOT:-"${DATA_DIR}/coco"}
+RUN_NAME=${RUN_NAME:-"Qwen2.5-VL-3B-Instruct-seg"}
 CHECKPOINT_STEPS=${CHECKPOINT_STEPS:-100}
 MODEL_PATH=${MODEL_PATH:-"${REPO_HOME}/checkpoints/rl/${RUN_NAME}/checkpoint-${CHECKPOINT_STEPS}"}
-DATA_ROOT=${DATA_ROOT:-"${DATA_DIR}/rec_jsons_processed"}
-IMAGE_ROOT=${IMAGE_ROOT:-"${DATA_DIR}/coco/train2014"}
-SEG_MASK_ROOT=${SEG_MASK_ROOT:-"${DATA_DIR}/grefcoco_masks"}
+IMAGE_ROOT=${IMAGE_ROOT:-"${COCO_IMAGE_ROOT}/train2014"}
+SEG_MASK_ROOT=${SEG_MASK_ROOT:-"${REFCOCO_EXPORT_BASE}"}
 SAM2_CKPT=${SAM2_CKPT:-"${REPO_HOME}/checkpoints/sam2/sam2_hiera_large.pt"}
 SAM2_MODEL=${SAM2_MODEL:-"sam2_hiera_large"}
 SAM2_DEVICE=${SAM2_DEVICE:-"cuda"}
-TEST_DATASETS=${TEST_DATASETS:-"refcoco_val,refcocop_val,refcocog_val"}
-OUTPUT_PATH=${OUTPUT_PATH:-"${REPO_HOME}/logs/rec_results_{DATASET}_${RUN_NAME}_${CHECKPOINT_STEPS}.json"}
+TEST_DATASETS=${TEST_DATASETS:-""}
+OUTPUT_DIR=${OUTPUT_DIR:-"${REPO_HOME}/logs"}
 NUM_GPUS=${NUM_GPUS:-8}
 NUM_SAMPLES=${NUM_SAMPLES:-2000}
 BSZ=${BSZ:-2}
@@ -30,24 +31,67 @@ if [[ ! -f "${SAM2_CKPT}" ]]; then
   exit 1
 fi
 
+if [[ ! -d "${REFCOCO_EXPORT_BASE}" ]]; then
+  echo "RefCOCO export directory not found at ${REFCOCO_EXPORT_BASE}." >&2
+  echo "Run prepare_refcoco_dataset.sh and export the metadata first." >&2
+  exit 1
+fi
+
 if [[ ! -d "${SEG_MASK_ROOT}" ]]; then
   echo "SEG_MASK_ROOT not found at ${SEG_MASK_ROOT}. Set SEG_MASK_ROOT to a valid directory." >&2
   exit 1
 fi
 
+mapfile -t DATA_PATHS < <(find "${REFCOCO_EXPORT_BASE}" -maxdepth 2 -name "metadata.jsonl" | sort)
+if [[ ${#DATA_PATHS[@]} -eq 0 ]]; then
+  echo "No metadata.jsonl files detected under ${REFCOCO_EXPORT_BASE}." >&2
+  echo "Execute prepare_refcoco_dataset.sh and run the printed python commands to generate exports." >&2
+  exit 1
+fi
+
+FILTERED_DATA_PATHS=()
+if [[ -n "${TEST_DATASETS}" ]]; then
+  IFS=',' read -r -a REQUESTED_DATASETS <<< "${TEST_DATASETS}"
+  for dataset in "${REQUESTED_DATASETS[@]}"; do
+    dataset="$(echo "${dataset}" | xargs)"
+    [[ -z "${dataset}" ]] && continue
+    candidate="${REFCOCO_EXPORT_BASE}/${dataset}/metadata.jsonl"
+    if [[ -f "${candidate}" ]]; then
+      FILTERED_DATA_PATHS+=("${candidate}")
+      continue
+    fi
+    for path in "${DATA_PATHS[@]}"; do
+      if [[ "${path}" == *"/${dataset}/metadata.jsonl" ]]; then
+        FILTERED_DATA_PATHS+=("${path}")
+      fi
+    done
+  done
+  if [[ ${#FILTERED_DATA_PATHS[@]} -eq 0 ]]; then
+    echo "Requested datasets did not match exports under ${REFCOCO_EXPORT_BASE}." >&2
+    exit 1
+  fi
+else
+  FILTERED_DATA_PATHS=("${DATA_PATHS[@]}")
+fi
+
+join_colon() {
+  local IFS=':'
+  echo "$*"
+}
+
+DATA_PATHS_STR="$(join_colon "${FILTERED_DATA_PATHS[@]}")"
+
 export SEG_MASK_ROOT
 export SAM2_CKPT SAM2_MODEL SAM2_DEVICE
-export REC_EVAL_STEPS="${CHECKPOINT_STEPS}"
-export REC_EVAL_RUN_NAME="${RUN_NAME}"
-export REC_EVAL_MODEL_PATH="${MODEL_PATH}"
-export REC_EVAL_DATA_ROOT="${DATA_ROOT}"
-export REC_EVAL_IMAGE_ROOT="${IMAGE_ROOT}"
-export REC_EVAL_DATASETS="${TEST_DATASETS}"
-export REC_EVAL_OUTPUT_PATH="${OUTPUT_PATH}"
-export REC_EVAL_NUM_SAMPLES="${NUM_SAMPLES}"
-export REC_EVAL_BSZ="${BSZ}"
+export SEG_EVAL_MODEL_PATH="${MODEL_PATH}"
+export SEG_EVAL_DATA_ROOT="${REFCOCO_EXPORT_BASE}"
+export SEG_EVAL_IMAGE_ROOT="${IMAGE_ROOT}"
+export SEG_EVAL_DATA_PATHS="${DATA_PATHS_STR}"
+export SEG_EVAL_OUTPUT_DIR="${OUTPUT_DIR}"
+export SEG_EVAL_NUM_SAMPLES="${NUM_SAMPLES}"
+export SEG_EVAL_BSZ="${BSZ}"
 
 cd "${REPO_HOME}/src/eval"
-torchrun --nproc_per_node="${NUM_GPUS}" test_rec_r1.py
+torchrun --nproc_per_node="${NUM_GPUS}" test_seg_r1.py
 
-echo "Evaluation complete. Results saved under ${OUTPUT_PATH}"
+echo "Evaluation complete. Results saved under ${OUTPUT_DIR}"


### PR DESCRIPTION
### Motivation
- Allow segmentation evaluation to run directly against RefCOCO export directories (`metadata.jsonl`) instead of hardcoded flat JSON files. 
- Make the segmentation eval driver script configurable via environment variables and able to filter which exported datasets to run. 
- Fix dataset loading/indentation and result naming in the segmentation evaluator so outputs map to the corresponding export directories.

### Description
- Updated `eval_grefcoco_rec.sh` to discover exports under `REFCOCO_EXPORT_BASE`, build a colon-separated `DATA_PATHS` list, allow filtering via `TEST_DATASETS`, and set new environment variables consumed by the evaluator (e.g. `SEG_EVAL_DATA_PATHS`, `SEG_EVAL_*`).
- Replaced the torchrun target to call `test_seg_r1.py` and aligned defaults to use `REFCOCO_EXPORT_BASE`/COCO image roots and `SEG_MASK_ROOT` for masks.
- Enhanced `src/eval/test_seg_r1.py` by adding `dataset_name_from_path` and `resolve_dataset_entries` to support metadata exports or explicit `data_paths` via `data_paths_env`, fixed dataset file reading/indentation, and made the script configurable via `SEG_EVAL_*` environment variables.
- Changed result file naming to include the resolved dataset name and parameterized batch size, sample count, device map, and output dir via env vars.

### Testing
- No automated tests were executed for these changes.
- Changes were committed to the working tree and are ready for CI or local validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954c87074188330bcfc62bd934c2635)